### PR TITLE
Use dependsOn: assembleDebug where appropriate

### DIFF
--- a/config/quality.gradle
+++ b/config/quality.gradle
@@ -14,7 +14,7 @@ task checkstyle(type: Checkstyle) {
     classpath = files()
 }
 
-task findbugs(type: FindBugs) {
+task findbugs(type: FindBugs, dependsOn: assembleDebug) {
     ignoreFailures = false
     effort = "max"
     reportLevel = "high"


### PR DESCRIPTION
This change creates class files with debug symbols before running pmd
and findbugs.